### PR TITLE
Fixes to ProjectMusicController

### DIFF
--- a/addons/maaacks_game_template/base/scripts/MusicController.gd
+++ b/addons/maaacks_game_template/base/scripts/MusicController.gd
@@ -99,9 +99,12 @@ func _blend_in_stream_player( stream_player : AudioStreamPlayer ):
 	_reparent_music_player(stream_player)
 	_play_and_fade_in()
 
+func _node_matches_checks( node : Node ) -> bool:
+	return node is AudioStreamPlayer and node.autoplay and node.bus == audio_bus
+
 func check_for_music_player( node: Node ) -> void:
 	if node == music_stream_player : return
-	if not (node is AudioStreamPlayer and node.autoplay) : return
+	if not (_node_matches_checks(node)) : return
 	if _is_matching_stream(node):
 		blend_to(node.volume_db, blend_volume_duration)
 		node.stop()

--- a/addons/maaacks_game_template/base/scripts/MusicController.gd
+++ b/addons/maaacks_game_template/base/scripts/MusicController.gd
@@ -116,7 +116,7 @@ func check_for_music_player( node: Node ) -> void:
 			return
 		_blend_in_stream_player(node)
 
-func _ready() -> void:
+func _enter_tree() -> void:
 	var tree_node = get_tree()
 	if not tree_node.node_added.is_connected(check_for_music_player):
 		tree_node.node_added.connect(check_for_music_player)


### PR DESCRIPTION
Fixes to:
- limiting affect to players with a matching audio bus.
- detecting and reparenting BackgroundMusicPlayer in Opening.tscn.