### PR TITLE
Lazy music player reparenting

### DIFF
--- a/addons/maaacks_game_template/base/scenes/Menus/OptionsMenu/Audio/AudioOptionsMenu.gd
+++ b/addons/maaacks_game_template/base/scenes/Menus/OptionsMenu/Audio/AudioOptionsMenu.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const SYSTEM_BUS_PREFIX : String = "System"
+
 @export var audio_control_scene : PackedScene
 @export var hide_busses : Array[String]
 
@@ -8,8 +10,8 @@ extends Control
 func _on_bus_changed(bus_value : float, bus_name : String):
 	AppSettings.set_bus_volume_from_linear(bus_name, bus_value)
 
-func _add_audio_control(bus_name, bus_value):
-	if audio_control_scene == null or bus_name in hide_busses:
+func _add_audio_control(bus_name : String, bus_value : float):
+	if audio_control_scene == null or bus_name in hide_busses or bus_name.begins_with(SYSTEM_BUS_PREFIX):
 		return
 	var audio_control = audio_control_scene.instantiate()
 	%AudioControlContainer.call_deferred("add_child", audio_control)

--- a/addons/maaacks_game_template/base/scripts/MusicController.gd
+++ b/addons/maaacks_game_template/base/scripts/MusicController.gd
@@ -39,7 +39,7 @@ var music_stream_player : AudioStreamPlayer
 
 func fade_out( duration : float = 0.0 ):
 	if not is_zero_approx(duration):
-		var tween = get_tree().create_tween()
+		var tween = create_tween()
 		tween.tween_property(music_stream_player, "volume_db", MINIMUM_VOLUME_DB, duration)
 		return tween
 
@@ -47,13 +47,13 @@ func fade_in( duration : float = 0.0 ):
 	if not is_zero_approx(duration):
 		var target_volume_db = music_stream_player.volume_db
 		music_stream_player.volume_db = MINIMUM_VOLUME_DB
-		var tween = get_tree().create_tween()
+		var tween = create_tween()
 		tween.tween_property(music_stream_player, "volume_db", target_volume_db, duration)
 		return tween
 
 func blend_to( target_volume_db : float, duration : float = 0.0 ):
 	if not is_zero_approx(duration):
-		var tween = get_tree().create_tween()
+		var tween = create_tween()
 		tween.tween_property(music_stream_player, "volume_db", target_volume_db, duration)
 		return tween
 	music_stream_player.volume_db = target_volume_db

--- a/addons/maaacks_game_template/base/scripts/MusicController.gd
+++ b/addons/maaacks_game_template/base/scripts/MusicController.gd
@@ -74,7 +74,10 @@ func stop():
 func play( playback_position : float = 0.0 ):
 	if music_stream_player == null:
 		return
-	music_stream_player.play(playback_position)
+	if is_zero_approx(playback_position) and not music_stream_player.playing:
+		music_stream_player.play()
+	else:
+		music_stream_player.play(playback_position)
 
 func _fade_out_and_free():
 	if music_stream_player == null:
@@ -86,10 +89,7 @@ func _fade_out_and_free():
 	stream_player.queue_free()
 
 func _play_and_fade_in():
-	if music_stream_player == null:
-		return
-	if not music_stream_player.playing:
-		music_stream_player.play()
+	play()
 	fade_in( fade_in_duration )
 
 func _is_matching_stream( stream_player : AudioStreamPlayer ) -> bool:
@@ -104,8 +104,8 @@ func _connect_stream_on_tree_exiting( stream_player : AudioStreamPlayer ):
 		stream_player.tree_exiting.connect(_on_removed_music_player.bind(stream_player))
 
 func _blend_and_remove_stream_player( stream_player : AudioStreamPlayer ):
-	var old_stream_player = music_stream_player
 	var playback_position := music_stream_player.get_playback_position()
+	var old_stream_player = music_stream_player
 	music_stream_player = stream_player
 	music_stream_player.bus = blend_audio_bus
 	if not music_stream_player.playing:


### PR DESCRIPTION
Allows for animating and editing the music player in the originating scene. Does not reparent the player until it is being unloaded by the scene.