### PR TITLE
Fixes for 0.15.0

### DIFF
--- a/addons/maaacks_game_template/base/scenes/menus/options_menu/input/input_options_menu.gd
+++ b/addons/maaacks_game_template/base/scenes/menus/options_menu/input/input_options_menu.gd
@@ -30,6 +30,7 @@ func _horizontally_align_popup_labels():
 	$ResetConfirmationDialog.get_label().horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 
 func _ready():
+	remapping_mode = remapping_mode
 	if Engine.is_editor_hint(): return
 	_horizontally_align_popup_labels()
 

--- a/addons/maaacks_game_template/examples/scenes/menus/options_menu/audio/audio_input_option_control.tscn
+++ b/addons/maaacks_game_template/examples/scenes/menus/options_menu/audio/audio_input_option_control.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://dxj1gsxtlp6v0"]
 
 [ext_resource type="PackedScene" uid="uid://b6bl3n5mp3m1e" path="res://addons/maaacks_game_template/base/scenes/menus/options_menu/option_control/list_option_control.tscn" id="1_0vgeo"]
-[ext_resource type="Script" uid="uid://bwiyqjcudqioy" path="res://addons/maaacks_game_template/examples/scenes/menus/options_menu/audio/audio_input_option_control.gd" id="2_6qeue"]
+[ext_resource type="Script" path="res://addons/maaacks_game_template/examples/scenes/menus/options_menu/audio/audio_input_option_control.gd" id="2_6qeue"]
 
 [node name="AudioInputOptionControl" instance=ExtResource("1_0vgeo")]
 script = ExtResource("2_6qeue")

--- a/addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.gd
+++ b/addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.gd
@@ -1,1 +1,2 @@
+@tool
 extends InputOptionsMenu

--- a/addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.tscn
+++ b/addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://1e3vf4u3brfm"]
 
 [ext_resource type="PackedScene" uid="uid://dp3rgqaehb3xu" path="res://addons/maaacks_game_template/base/scenes/menus/options_menu/input/input_options_menu.tscn" id="1_b6ygu"]
-[ext_resource type="Script" uid="uid://bg7vtixswgqhd" path="res://addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.gd" id="2_gjulr"]
+[ext_resource type="Script" path="res://addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.gd" id="2_gjulr"]
 
 [node name="Controls" instance=ExtResource("1_b6ygu")]
 script = ExtResource("2_gjulr")

--- a/addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu_with_mouse_sensitivity.tscn
+++ b/addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu_with_mouse_sensitivity.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://dp3rgqaehb3xu" path="res://addons/maaacks_game_template/base/scenes/menus/options_menu/input/input_options_menu.tscn" id="1_pi4g6"]
 [ext_resource type="PackedScene" uid="uid://cl416gdb1fgwr" path="res://addons/maaacks_game_template/base/scenes/menus/options_menu/option_control/slider_option_control.tscn" id="2_ax2ge"]
-[ext_resource type="Script" uid="uid://bg7vtixswgqhd" path="res://addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.gd" id="2_diymx"]
+[ext_resource type="Script" path="res://addons/maaacks_game_template/examples/scenes/menus/options_menu/input/input_options_menu.gd" id="2_diymx"]
 
 [node name="Controls" instance=ExtResource("1_pi4g6")]
 script = ExtResource("2_diymx")

--- a/addons/maaacks_game_template/maaacks_game_template.gd
+++ b/addons/maaacks_game_template/maaacks_game_template.gd
@@ -173,7 +173,6 @@ func _copy_override_file():
 
 func _copy_file_path(file_path : String, destination_path : String, target_path : String, raw_copy_file_extensions : PackedStringArray = []) -> Error:
 	if file_path.get_extension() in raw_copy_file_extensions:
-		# Markdown file format
 		return _raw_copy_file_path(file_path, destination_path)
 	var error = _save_resource(file_path, destination_path)
 	if error == ERR_FILE_UNRECOGNIZED:
@@ -248,7 +247,7 @@ func _copy_to_directory(target_path : String):
 	ProjectSettings.save()
 	if not target_path.ends_with("/"):
 		target_path += "/"
-	_copy_directory_path(get_plugin_examples_path(), target_path, ["md"])
+	_copy_directory_path(get_plugin_examples_path(), target_path, ["md", "txt", "uid"])
 	_update_scene_loader_path(target_path)
 	_copy_override_file()
 	_delayed_saving_and_check_main_scene(target_path)

--- a/addons/maaacks_game_template/maaacks_game_template.gd
+++ b/addons/maaacks_game_template/maaacks_game_template.gd
@@ -10,7 +10,7 @@ const MAIN_SCENE_UPDATE_TEXT = "Current:\n%s\n\nNew:\n%s\n"
 const OVERRIDE_RELATIVE_PATH = "installer/override.cfg"
 const SCENE_LOADER_RELATIVE_PATH = "base/scenes/autoloads/scene_loader.tscn"
 const UID_PREG_MATCH = r'uid="uid:\/\/[0-9a-z]+" '
-const WINDOW_CLOSE_DELAY : float = 1.5
+const WINDOW_OPEN_DELAY : float = 1.5
 const RUNNING_CHECK_DELAY : float = 0.25
 const RESAVING_DELAY : float = 1.0
 const OPEN_EDITOR_DELAY : float = 0.1
@@ -216,7 +216,7 @@ func _delayed_play_opening_confirmation_dialog(target_path : String):
 		timer.queue_free()
 	timer.timeout.connect(callable)
 	add_child(timer)
-	timer.start(WINDOW_CLOSE_DELAY)
+	timer.start(WINDOW_OPEN_DELAY)
 
 func _wait_for_scan_and_delay_next_prompt(target_path : String):
 	var timer: Timer = Timer.new()

--- a/addons/maaacks_game_template/plugin.cfg
+++ b/addons/maaacks_game_template/plugin.cfg
@@ -5,5 +5,5 @@ description="Template with a main menu, options menus, pause menu, credits, scen
 
 Created in collaboration with members of the Godot Wild Jam community."
 author="Marek Belski"
-version="0.15.0"
+version="0.15.1"
 script="maaacks_game_template.gd"

--- a/scenes/menus/options_menu/input/input_options_menu.gd
+++ b/scenes/menus/options_menu/input/input_options_menu.gd
@@ -1,1 +1,2 @@
+@tool
 extends InputOptionsMenu


### PR DESCRIPTION
Clears warnings and errors on file copy.
Fixes UI input remapping mode not updating node visibility.