### PR TITLE
Add github workflow to keep main-plugin synced with main

### DIFF
--- a/.github/workflows/sync-main-to-plugin.yml
+++ b/.github/workflows/sync-main-to-plugin.yml
@@ -1,0 +1,35 @@
+name: Auto Merge main into main-plugin
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Git
+        # Set up bot account to commit automated changes
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+
+      - name: Checkout main-plugin branch
+        run: git checkout main-plugin
+
+      - name: Merge main into main-plugin
+        # --no-ff: Always create a merge commit to maintain a clear history of merges.
+        # --no-edit: Don't prompt but use the default merge message.
+        run: git merge main --no-ff --no-edit
+
+      - name: Push changes
+        run: git push origin main-plugin
+        env:
+          # `GITHUB_TOKEN` is automatically available on Github
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The `examples/` folder contains an example project using inherited scenes from t
 - `opening.tscn` is a simple scene for fading in/out a few images at the start of the game. It then loads the next scene (`main_menu.tscn`).  
 - `main_menu.tscn` is where a player can start the game, change settings, watch credits, or quit. It can link to the path of a game scene to play, and the packed scene of an options menu to use.  
 - `option_control.tscn` and its inherited scenes are used for most configurable options in the menus. They work with `config.gd` to keep settings persistent between runs.
-- `credits.tscn` reads from `ATTRIBUTION.md` to automatically generate the content for it's scrolling text label.  
+- `credits.tscn` reads from `ATTRIBUTION.md` to automatically generate the content for its scrolling text label.  
 - The `UISoundController` node automatically attaches sounds to buttons, tab bars, sliders, and line edits in the scene. `project_ui_sound_controller.tscn` is an autload used to apply UI sounds project-wide.
 - `project_music_controller.tscn` is an autoload that keeps music playing between scenes. It detects music stream players as they are added to the scene tree, reparents them to itself, and blends the tracks.  
 - The `PauseMenuController` node loads the `pause_menu.tscn` when triggering `ui-cancel`.


### PR DESCRIPTION
You can check out the successful workflow execution for my example push to `main`: https://github.com/3ter/Godot-Game-Template/actions/runs/12722212515.

You could also add tags this way accordingly so I hope this helps with #43.