### PR TITLE
Add itemlist ui sounds

### DIFF
--- a/addons/maaacks_game_template/base/scripts/ui_sound_controller.gd
+++ b/addons/maaacks_game_template/base/scripts/ui_sound_controller.gd
@@ -39,6 +39,10 @@ const MAX_DEPTH = 16
 @export var line_text_submitted : AudioStream
 @export var line_text_change_rejected : AudioStream
 
+@export_group("ItemList Sounds")
+@export var item_list_activated : AudioStream
+@export var item_list_selected : AudioStream
+
 @onready var root_node : Node = get_node(root_path)
 
 var button_hovered_player : AudioStreamPlayer
@@ -59,6 +63,9 @@ var line_focused_player : AudioStreamPlayer
 var line_text_changed_player : AudioStreamPlayer
 var line_text_submitted_player : AudioStreamPlayer
 var line_text_change_rejected_player : AudioStreamPlayer
+
+var item_list_activated_player : AudioStreamPlayer
+var item_list_selected_player : AudioStreamPlayer
 
 func _update_persistent_signals() -> void:
 	if not is_inside_tree():
@@ -104,12 +111,17 @@ func _build_line_stream_players() -> void:
 	line_text_submitted_player = _build_stream_player(line_text_submitted, "LineTextSubmitted")
 	line_text_change_rejected_player = _build_stream_player(line_text_change_rejected, "LineTextChangeRejected")
 
+func _build_item_list_stream_players() -> void:
+	item_list_activated_player = _build_stream_player(item_list_activated,"ItemActivated")
+	item_list_selected_player = _build_stream_player(item_list_selected,"ItemSelected")
+
 func _build_all_stream_players() -> void:
 	_build_button_stream_players()
 	_build_tab_stream_players()
 	_build_slider_stream_players()
 	_build_line_stream_players()
-
+	_build_item_list_stream_players()
+	
 func _play_stream(stream_player : AudioStreamPlayer) -> void:
 	if not stream_player.is_inside_tree():
 		return
@@ -122,6 +134,9 @@ func _slider_drag_ended_play_stream(_value_changed : bool, stream_player : Audio
 	_play_stream(stream_player)
 
 func _line_event_play_stream(_new_text : String, stream_player : AudioStreamPlayer) -> void:
+	_play_stream(stream_player)
+
+func _item_list_play_stream(_index : int, stream_player : AudioStreamPlayer) -> void:
 	_play_stream(stream_player)
 
 func _connect_stream_player(node : Node, stream_player : AudioStreamPlayer, signal_name : StringName, callable : Callable) -> void:
@@ -148,7 +163,10 @@ func connect_ui_sounds(node: Node) -> void:
 		_connect_stream_player(node, line_text_changed_player, &"text_changed", _line_event_play_stream)
 		_connect_stream_player(node, line_text_submitted_player, &"text_submitted", _line_event_play_stream)
 		_connect_stream_player(node, line_text_change_rejected_player, &"text_change_rejected", _line_event_play_stream)
-
+	elif node is ItemList:
+		_connect_stream_player(node, item_list_activated_player, &"item_activated", _item_list_play_stream)
+		_connect_stream_player(node, item_list_selected_player, &"item_selected", _item_list_play_stream)
+		
 func _recursive_connect_ui_sounds(current_node: Node, current_depth : int = 0) -> void:
 	if current_depth >= MAX_DEPTH:
 		return


### PR DESCRIPTION
Added and tested, matching preferred formatting. Like i mentioned to Maaack previously: this adds ui sounds for item_selected and item_activated, but not other signals relating to click actions since those are included in the actions to select or activate, so seemed redundant.