### PR TITLE
Loading screen level reloading fix

### DIFF
--- a/addons/maaacks_game_template/base/scenes/autoloads/scene_loader.gd
+++ b/addons/maaacks_game_template/base/scenes/autoloads/scene_loader.gd
@@ -98,9 +98,8 @@ func load_scene(scene_path : String, in_background : bool = false) -> void:
 			change_scene_to_resource()
 		return
 	ResourceLoader.load_threaded_request(_scene_path)
-	if _background_loading or not _check_loading_screen():
-		set_process(true)
-	else:
+	set_process(true)
+	if _check_loading_screen() and not _background_loading:
 		change_scene_to_loading_screen()
 
 func _unhandled_key_input(event : InputEvent) -> void:

--- a/addons/maaacks_game_template/base/scenes/loading_screen/loading_screen.gd
+++ b/addons/maaacks_game_template/base/scenes/loading_screen/loading_screen.gd
@@ -124,7 +124,7 @@ func _update_progress_messaging() -> void:
 		_hide_popups()
 
 func _process(_delta : float) -> void:
-	_try_loading_next_scene()
+	# _try_loading_next_scene()
 	var status = SceneLoader.get_status()
 	match(status):
 		ResourceLoader.THREAD_LOAD_IN_PROGRESS:

--- a/addons/maaacks_game_template/base/scenes/loading_screen/loading_screen.gd
+++ b/addons/maaacks_game_template/base/scenes/loading_screen/loading_screen.gd
@@ -25,8 +25,6 @@ var _scene_loading_progress : float = 0.0 :
 		if _value_changed:
 			update_total_loading_progress()
 			_reset_loading_stage()
-
-var _changing_to_next_scene : bool = false
 var _total_loading_progress : float = 0.0 :
 	set(value):
 		_total_loading_progress = value
@@ -42,17 +40,6 @@ func _reset_loading_stage() -> void:
 
 func _reset_loading_start_time() -> void:
 	_loading_start_time = Time.get_ticks_msec()
-
-func _try_loading_next_scene() -> void:
-	if not _scene_loading_complete:
-		return
-	_load_next_scene()
-
-func _load_next_scene() -> void:
-	if _changing_to_next_scene:
-		return
-	_changing_to_next_scene = true
-	SceneLoader.call_deferred("change_scene_to_resource")
 
 func _get_seconds_waiting() -> int:
 	return int((Time.get_ticks_msec() - _loading_start_time) / 1000.0)
@@ -124,7 +111,6 @@ func _update_progress_messaging() -> void:
 		_hide_popups()
 
 func _process(_delta : float) -> void:
-	# _try_loading_next_scene()
 	var status = SceneLoader.get_status()
 	match(status):
 		ResourceLoader.THREAD_LOAD_IN_PROGRESS:


### PR DESCRIPTION
General idea is to move responsibility of loading the next scene away from the loading screen, and into the scene loader. The code has worked this way for a long time, and likely an artifact of an old design decision that doesn't make sense anymore.