### PR TITLE
Moves game resetting to the GameState class

### DIFF
--- a/addons/maaacks_game_template/examples/scenes/menus/main_menu/main_menu.gd
+++ b/addons/maaacks_game_template/examples/scenes/menus/main_menu/main_menu.gd
@@ -13,7 +13,7 @@ func new_game() -> void:
 	if confirm_new_game and GameStateExample.has_game_state():
 		%NewGameConfirmationDialog.popup_centered()
 	else:
-		GlobalState.reset()
+		GameStateExample.reset()
 		load_game_scene()
 
 func _add_level_select_if_set() -> void: 
@@ -43,5 +43,5 @@ func _on_level_select_button_pressed() -> void:
 	_open_sub_menu(level_select_scene)
 
 func _on_new_game_confirmation_dialog_confirmed() -> void:
-	GlobalState.reset()
+	GameStateExample.reset()
 	load_game_scene()

--- a/addons/maaacks_game_template/examples/scenes/menus/main_menu/main_menu_with_animations.gd
+++ b/addons/maaacks_game_template/examples/scenes/menus/main_menu/main_menu_with_animations.gd
@@ -14,7 +14,7 @@ func new_game() -> void:
 	if confirm_new_game and GameStateExample.has_game_state():
 		%NewGameConfirmationDialog.popup_centered()
 	else:
-		GlobalState.reset()
+		GameStateExample.reset()
 		load_game_scene()
 
 func intro_done() -> void:
@@ -71,5 +71,5 @@ func _on_level_select_button_pressed() -> void:
 	_open_sub_menu(level_select_scene)
 
 func _on_new_game_confirmation_dialog_confirmed():
-	GlobalState.reset()
+	GameStateExample.reset()
 	load_game_scene()

--- a/addons/maaacks_game_template/examples/scenes/menus/options_menu/game/game_options_menu.gd
+++ b/addons/maaacks_game_template/examples/scenes/menus/options_menu/game/game_options_menu.gd
@@ -1,4 +1,4 @@
 extends Control
 
 func _on_ResetGameControl_reset_confirmed() -> void:
-	GlobalState.reset()
+	GameStateExample.reset()

--- a/addons/maaacks_game_template/examples/scenes/menus/options_menu/mini_options_menu_with_reset.gd
+++ b/addons/maaacks_game_template/examples/scenes/menus/options_menu/mini_options_menu_with_reset.gd
@@ -1,4 +1,4 @@
 extends MiniOptionsMenu
 
 func _on_reset_game_control_reset_confirmed() -> void:
-	GlobalState.reset()
+	GameStateExample.reset()

--- a/addons/maaacks_game_template/examples/scripts/game_state.gd
+++ b/addons/maaacks_game_template/examples/scripts/game_state.gd
@@ -61,3 +61,10 @@ static func continue_game() -> void:
 	var game_state := get_or_create_state()
 	game_state.current_level_path = game_state.continue_level_path
 	GlobalState.save()
+
+static func reset() -> void:
+	var game_state := get_or_create_state()
+	game_state.level_states = {}
+	game_state.current_level_path = ""
+	game_state.continue_level_path = ""
+	GlobalState.save()

--- a/scenes/menus/main_menu/main_menu.gd
+++ b/scenes/menus/main_menu/main_menu.gd
@@ -13,7 +13,7 @@ func new_game() -> void:
 	if confirm_new_game and GameState.has_game_state():
 		%NewGameConfirmationDialog.popup_centered()
 	else:
-		GlobalState.reset()
+		GameState.reset()
 		load_game_scene()
 
 func _add_level_select_if_set() -> void: 
@@ -43,5 +43,5 @@ func _on_level_select_button_pressed() -> void:
 	_open_sub_menu(level_select_scene)
 
 func _on_new_game_confirmation_dialog_confirmed() -> void:
-	GlobalState.reset()
+	GameState.reset()
 	load_game_scene()

--- a/scenes/menus/main_menu/main_menu_with_animations.gd
+++ b/scenes/menus/main_menu/main_menu_with_animations.gd
@@ -14,7 +14,7 @@ func new_game() -> void:
 	if confirm_new_game and GameState.has_game_state():
 		%NewGameConfirmationDialog.popup_centered()
 	else:
-		GlobalState.reset()
+		GameState.reset()
 		load_game_scene()
 
 func intro_done() -> void:
@@ -71,5 +71,5 @@ func _on_level_select_button_pressed() -> void:
 	_open_sub_menu(level_select_scene)
 
 func _on_new_game_confirmation_dialog_confirmed():
-	GlobalState.reset()
+	GameState.reset()
 	load_game_scene()

--- a/scenes/menus/options_menu/game/game_options_menu.gd
+++ b/scenes/menus/options_menu/game/game_options_menu.gd
@@ -1,4 +1,4 @@
 extends Control
 
 func _on_ResetGameControl_reset_confirmed() -> void:
-	GlobalState.reset()
+	GameState.reset()

--- a/scenes/menus/options_menu/mini_options_menu_with_reset.gd
+++ b/scenes/menus/options_menu/mini_options_menu_with_reset.gd
@@ -1,4 +1,4 @@
 extends MiniOptionsMenu
 
 func _on_reset_game_control_reset_confirmed() -> void:
-	GlobalState.reset()
+	GameState.reset()

--- a/scripts/game_state.gd
+++ b/scripts/game_state.gd
@@ -61,3 +61,10 @@ static func continue_game() -> void:
 	var game_state := get_or_create_state()
 	game_state.current_level_path = game_state.continue_level_path
 	GlobalState.save()
+
+static func reset() -> void:
+	var game_state := get_or_create_state()
+	game_state.level_states = {}
+	game_state.current_level_path = ""
+	game_state.continue_level_path = ""
+	GlobalState.save()


### PR DESCRIPTION
`GlobalState.reset()` is not the call or functionality one would expect from doing a call to a "Game Reset". This makes it more specific to the game state.