### PR TITLE
Adds simpler win lose manager

### DIFF
--- a/addons/maaacks_game_template/docs/GameSceneSetup.md
+++ b/addons/maaacks_game_template/docs/GameSceneSetup.md
@@ -32,7 +32,9 @@ In that case, the following nodes can be safely removed:
 * LevelManager
 * LevelLoadingScreen
   
-The single level scene can then be added directly to the `SubViewport`, another container, or the root node.
+The single level scene can then be added directly to the `SubViewport`, another container, or the root node.  
+
+To manage the win and lose screens and transitioning to other scenes, add a `Node` and attach the `win_lose_manager.gd` script. Inspect the node to attach the win / lose screens. The `game_won()` or `game_lost()` will then need to be called when gameplay conditions are met.  
 
 ## Background Music
 `BackgroundMusicPlayer`'s are `AudioStreamPlayer`'s with `autoplay` set to `true` and `audio_bus` set to "Music". These will automatically be recognized by the `ProjectMusicController` with the default settings, and allow for blending between tracks.

--- a/addons/maaacks_game_template/extras/scripts/win_lose_manager.gd
+++ b/addons/maaacks_game_template/extras/scripts/win_lose_manager.gd
@@ -1,0 +1,64 @@
+extends Node
+
+@export_group("Scenes")
+## Path to a main menu scene.
+## Will attempt to read from AppConfig if left empty.
+@export_file("*.tscn") var main_menu_scene_path : String
+## Optional path to an ending scene.
+## Will attempt to read from AppConfig if left empty
+@export_file("*.tscn") var ending_scene_path : String
+## Optional screen to be shown after the game is won.
+@export var game_won_scene : PackedScene
+## Optional screen to be shown after the game is lost.
+@export var game_lost_scene : PackedScene
+
+func _try_connecting_signal_to_node(node : Node, signal_name : String, callable : Callable) -> void:
+	if node.has_signal(signal_name) and not node.is_connected(signal_name, callable):
+		node.connect(signal_name, callable)
+
+func get_main_menu_scene_path() -> String:
+	if main_menu_scene_path.is_empty():
+		return AppConfig.main_menu_scene_path
+	return main_menu_scene_path
+
+func _load_main_menu() -> void:
+	SceneLoader.load_scene(get_main_menu_scene_path())
+
+func get_ending_scene_path() -> String:
+	if ending_scene_path.is_empty():
+		return AppConfig.ending_scene_path
+	return ending_scene_path
+
+func _load_ending() -> void:
+	if not get_ending_scene_path().is_empty():
+		SceneLoader.load_scene(get_ending_scene_path())
+	else:
+		_load_main_menu()
+
+func _load_lose_screen_or_reload() -> void:
+	if game_lost_scene:
+		var instance = game_lost_scene.instantiate()
+		get_tree().current_scene.add_child(instance)
+		_try_connecting_signal_to_node(instance, &"restart_pressed", _reload_level)
+		_try_connecting_signal_to_node(instance, &"main_menu_pressed", _load_main_menu)
+	else:
+		_reload_level()
+
+func _reload_level() -> void:
+	SceneLoader.reload_current_scene()
+
+func _load_win_screen_or_ending() -> void:
+	if game_won_scene:
+		var instance = game_won_scene.instantiate()
+		get_tree().current_scene.add_child(instance)
+		_try_connecting_signal_to_node(instance, &"continue_pressed", _load_ending)
+		_try_connecting_signal_to_node(instance, &"restart_pressed", _reload_level)
+		_try_connecting_signal_to_node(instance, &"main_menu_pressed", _load_main_menu)
+	else:
+		_load_ending()
+
+func game_lost() -> void:
+	_load_lose_screen_or_reload()
+
+func game_won() -> void:
+	_load_win_screen_or_ending()

--- a/addons/maaacks_game_template/extras/scripts/win_lose_manager.gd.uid
+++ b/addons/maaacks_game_template/extras/scripts/win_lose_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bmlwpkrav3q56


### PR DESCRIPTION
For cases when developers don't need multiple levels, but still want a win / lose screen and transition out to other scenes.