### PR TITLE
Fixes links in credits label not responding to clicks

### DIFF
--- a/addons/maaacks_game_template/base/nodes/labels/credits_label.gd
+++ b/addons/maaacks_game_template/base/nodes/labels/credits_label.gd
@@ -109,5 +109,6 @@ func _on_meta_clicked(meta: String) -> void:
 		var _err = OS.shell_open(meta)
 
 func _ready() -> void:
+	meta_clicked.connect(_on_meta_clicked)
 	if not auto_update: return
 	set_file_path(attribution_file_path)


### PR DESCRIPTION
This signal must have gotten removed from a scene many months ago. Oops.