### PR TITLE
Fixes minimum sizes in the inputs options menu

### DIFF
--- a/addons/maaacks_game_template/base/nodes/menus/options_menu/input/input_options_menu.tscn
+++ b/addons/maaacks_game_template/base/nodes/menus/options_menu/input/input_options_menu.tscn
@@ -39,13 +39,13 @@ horizontal_alignment = 1
 
 [node name="InputActionsList" parent="VBoxContainer/InputMappingContainer" instance=ExtResource("4_lf2nw")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(560, 480)
+custom_minimum_size = Vector2(560, 440)
 layout_mode = 2
 
 [node name="InputActionsTree" parent="VBoxContainer/InputMappingContainer" instance=ExtResource("5_b2whh")]
 unique_name_in_owner = true
 visible = false
-custom_minimum_size = Vector2(400, 480)
+custom_minimum_size = Vector2(400, 440)
 layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/InputMappingContainer"]


### PR DESCRIPTION
It now works with default window size of 1152 x 648 (Ew).