### PR TITLE
Remove extra setting_changed emit and fix related bugs

### DIFF
--- a/addons/maaacks_game_template/base/nodes/menus/options_menu/option_control/list_option_control.gd
+++ b/addons/maaacks_game_template/base/nodes/menus/options_menu/option_control/list_option_control.gd
@@ -51,10 +51,10 @@ func _match_value_to_other(value : Variant, other : Variant) -> Variant:
 		return int(round(value))
 	return value
 
-func _set_value(value : Variant) -> Variant:
+func _refresh_option_values(value : Variant) -> void:
 	if option_values.is_empty(): return
 	if value == null:
-		return super._set_value(-1)
+		return
 	custom_option_values = option_values.duplicate()
 	value = _match_value_to_other(value, custom_option_values.front())
 	if value not in custom_option_values and typeof(value) == property_type:
@@ -63,8 +63,11 @@ func _set_value(value : Variant) -> Variant:
 	_set_titles_from_values()
 	if value not in option_values:
 		disable_option(custom_option_values.find(value))
+
+func set_value(value : Variant) -> void:
+	_refresh_option_values(value)
 	value = custom_option_values.find(value)
-	return super._set_value(value)
+	super.set_value(value)
 
 func _set_option_list(option_titles_list : Array) -> void:
 	%OptionButton.clear()

--- a/addons/maaacks_game_template/base/nodes/menus/options_menu/option_control/option_control.gd
+++ b/addons/maaacks_game_template/base/nodes/menus/options_menu/option_control/option_control.gd
@@ -88,7 +88,7 @@ func _connect_option_inputs(node) -> void:
 		node.text_changed.connect(_on_setting_changed)
 		_connected_nodes.append(node)
 
-func _set_value(value : Variant) -> Variant:
+func set_value(value : Variant) -> void:
 	if value == null:
 		return
 	for node in get_children():
@@ -103,11 +103,6 @@ func _set_value(value : Variant) -> Variant:
 			node.value = value as float
 		if node is LineEdit or node is TextEdit:
 			node.text = "%s" % value
-	return value
-
-func set_value(value : Variant) -> void:
-	value = _set_value(value)
-	_on_setting_changed(value)
 
 func set_editable(value : bool = true) -> void:
 	editable = value
@@ -123,7 +118,7 @@ func _ready() -> void:
 	option_name = option_name
 	property_type = property_type
 	default_value = default_value
-	_set_value(_get_setting(default_value))
+	set_value(_get_setting(default_value))
 	for child in get_children():
 		_connect_option_inputs(child)
 	child_entered_tree.connect(_connect_option_inputs)


### PR DESCRIPTION
Caused an issue in the 2.5D menus where the resolution kept getting reset when the options menu was opened.